### PR TITLE
meta: Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,55 @@
+name: Bug
+description: Something is broken
+title: "[Bug] <short summary>"
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Short description of the bug.
+      placeholder: "Short description of the bug."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected vs actual behavior
+      placeholder: |
+        Expected:
+        Actual:
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem_motivation
+    attributes:
+      label: Problem / Motivation
+      description: Why this bug matters (impact, severity).
+      placeholder: "Why do we care about this bug?"
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: When is this bug considered fixed?
+      placeholder: |
+        - [ ] Repro steps no longer reproduce the bug
+        - [ ] Test added/updated
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions / general discussion
+    url: [https://github.com/aleos-dev/singularity-project]
+    about: Use Discussions for questions or open-ended ideas, not issues.

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,60 @@
+name: General issue
+description: Feature, enhancement, chore or meta task
+title: "[Issue] <short summary>"
+labels: []
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Short description of the change.
+      placeholder: "Short description of the change."
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem_motivation
+    attributes:
+      label: Problem / Motivation
+      description: What’s wrong or missing now? Why does this matter?
+      placeholder: |
+        What’s wrong or missing now?
+        Why does this matter?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (optional)
+      description: What is in scope and explicitly out of scope.
+      placeholder: |
+        In scope:
+        - ...
+        Out of scope:
+        - ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: implementation_sketch
+    attributes:
+      label: Implementation sketch (optional)
+      description: Rough idea of how to approach this. Non-binding.
+      placeholder: |
+        - Rough steps
+        - Key considerations
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Checklist of what must be true to consider this done.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+What this PR does in 1–3 sentences.
+
+## Details
+
+- Key change 1
+- Key change 2
+- Any breaking or notable behavioral change
+
+## Testing
+
+- How this was tested (commands, scenarios).
+- If **not tested**, write: `Not tested because ...` and mention any risks.


### PR DESCRIPTION
## Summary

Introduce GitHub Issue Forms for bugs and general issues, and add a pull request templatec.

## Details

Closes #2.

## Testing

- Not tested: templates only; will be validated via GitHub “New issue” / “New pull request” flows.
