### PR TITLE
workflow: Refine contributing guide and workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Singularity – Development Guide
 
-It defines how we use issues, labels, branches, and pull requests when working on the project.
+This guide explains how we use issues, labels, branches, commits, and pull requests when working on Singularity.
 
-The goal is to keep the workflow predictable and avoid chaos.
+The goal is to keep the workflow predictable, traceable, and easy to work with over time.
 
 ---
 
@@ -16,7 +16,7 @@ Create an issue for:
 - Bug reports.
 - Refactors, build/CI changes, dependency updates.
 - Documentation work.
-- Project / repo / process changes (labels, CI, conventions, etc).
+- Project/repo/process changes (labels, CI, conventions, etc).
 
 Avoid drive-by changes without an issue, except for truly trivial fixes (typos in comments, tiny doc wording, etc).
 
@@ -31,223 +31,215 @@ Examples:
 
 - `Setup Gradle project`
 - `Define GitHub label scheme`
-- `Document label scheme in CONTRIBUTING`
 - `Fix NPE when payload is null`
 
-Do **not** put type/area prefixes in the title (`build:`, `meta:`, etc).  
-Type and area are represented by labels.
+Do **not** put type/area/priority prefixes in the issue title (`build:`, `meta:`, etc).  
 
-### 1.3 Labels
+### 1.3 Issue labels (overview)
 
-We use a small label set to keep the tracker readable.  
-These are **team conventions**; anyone on the project is expected to follow them.
+We use GitHub labels to classify issues and project items along four axes:
 
-#### Type labels (one per issue)
+- **Type** – what kind of work this is  
+- **Area** – which part of the system or process it primarily affects  
+- **Priority** – how urgent it is for the project  
+- **Workflow** – special handling / state (question, duplicate, wontfix, etc.)
 
-Exactly one of these should usually be applied:
+These axes are implemented as labels (for example, `feature`, `bug`,
+`priority:P1`, `question`), so that the project board stays easy to filter and scan.
 
-- `feature` – New feature or request.
-- `enhancement` – Small improvements or extensions to existing functionality; no brand-new features.
-- `bug` – Unexpected problem or incorrect behavior.
-- `chore` – Maintenance work: refactors, dependency bumps, build/CI tweaks without user-facing changes.
-- `documentation` – Improvements or additions to documentation.
-- `meta` – Project / repo / GitHub configuration and process tasks.
+When you create or triage an issue:
 
-#### Workflow labels (optional)
+- **Type**  
+  - Apply **exactly one** type label (required), e.g. `feature`, `enhancement`, `bug`, `chore`, `documentation`, `meta`.
+- **Area**  
+  - Apply **one** area label (required), e.g. `domain`, `auth`, `workflow`, `build`, `infra`.  
+  - If an issue truly affects multiple areas in a balanced way, you may add
+    more than one area label, but this should be rare. Prefer choosing the single
+    area with the most visible impact to keep filtering on the project board useful.
+- **Priority**  
+  - Apply **at most one** priority label (`priority:P0`..`priority:P3`).  
+  - New issues may be created without a priority; maintainers set or adjust priority during triage.
+- **Workflow**  
+  - Add workflow labels only when needed: `question`, `help wanted`, `good first issue`, `duplicate`, `wontfix`, etc.  
+  - These refine handling/state and never replace type, area, or priority.
 
-Use these to describe state or purpose:
+Full definitions of each label and axis live in [Project meta](docs/project-meta.md).
 
-- `question` – Issue needs clarification or more information.
-- `help wanted` – Another team member is invited to pick this up.
-- `duplicate` – This issue is already covered by another one.
-- `wontfix` – We decided not to work on this.
+### 1.4 Issue templates
 
-#### 1.4 When to reuse vs create new issues
+When opening an issue, use the provided templates under [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE):
 
-- If an existing issue already describes the same problem/feature, **reuse it** and add a comment.
-- If the behavior, area, or impact is clearly different, **open a new issue** and link related ones with references (`See #nn`).
+  - use the **general** template for features, enhancements, chores, and meta tasks;
+  - use the **bug** template for defects and regressions.
+
+The goal is to keep issues consistent and easy to triage.
+
+Templates are a starting point, not a straitjacket, but issues should contain at least the information these templates ask for.
 
 ---
 
 ## 2. Branches and commits
 
-### 2.1 Branch naming
+This section is a short version. Full details are in the [Git workflow](docs/git-workflow.md) document.
 
-Use short, descriptive names. Suggested patterns:
+### 2.1 Branching model (high-level)
 
-- `feature/<short-description>`
-- `bugfix/<short-description>`
-- `chore/<short-description>`
-- `docs/<short-description>`
-- `meta/<short-description>`
+We use a simple `main`/`develop` model:
+
+- `develop` is the primary **integration branch** for day-to-day work.
+- `main` is reserved for **release-ready** code and is updated from `develop` when a release is cut.
+
+### 2.2 Branch naming
+
+We use short-lived branches created from `develop` with names in the form:
+
+```text
+<issue-type>/<short-description>
+```
+- `<issue-type>` is usually one of: `feature`, `bugfix`, `chore`, `docs`, `meta`;
+- `<short-description>` is a short, kebab-case summary, e.g. `add-basic-login`.
+
+We do not encode issue numbers in branch names.
+
+For full details and examples, see the [Git workflow](docs/git-workflow.md#12-short-lived-branches).
+
+### 2.3 Commit messages
+
+At a glance, they usually look like:
+
+```text
+<type>: <short summary>
+```
 
 Examples:
 
-- `feature/authentication-flow`
-- `chore/gradle-setup`
-- `meta/label-scheme`
-
-These are conventions to keep history readable; they are not enforced by tools.
-
-### 2.2 Commit messages
-
-Use something close to Conventional Commits:
-
-- `feat: add login endpoint`
+- `feat: add refresh token support`
 - `fix: handle null payload in request`
-- `chore: update dependencies`
-- `docs: document label scheme`
 - `build: configure Gradle wrapper`
 
-Keep commit scope focused. Prefer several small commits over one giant “misc changes” blob.
+Keep commit scope focused and avoid huge “misc” blobs. 
 
-### 2.3 Branching model
+The detailed rules (allowed types, scopes, structure) are in the [Commit conventions](docs/commit-conventions.md) document.
 
-- The develop branch serves as the primary **integration point**; all changes are made via pull requests into it.
-- Features, bug fixes, documentation and other tasks should be carried out in short‑lived branches (like feature/..., bugfix/..., docs/..., etc.) created from develop, and then merged back into develo
+---
+
+### 2.4 Naming consistency (issue → branch → commit)
+
+As a rule of thumb, the “kind of work” stays the same across issues,
+branches, and commits, even if the wording changes:
+
+| Issue type      | Typical branch prefix      | Typical commit type(s) |
+|-----------------|----------------------------|------------------------|
+| `bug`           | `bugfix/...`               | `fix: ...`             |
+| `feature`       | `feature/...`              | `feat: ...`            |
+| `documentation` | `docs/...`                 | `docs: ...`            |
+| `meta`          | `meta/...`                 | `meta: ...`            |
+| `chore`         | `chore/...`                | `chore: ...`or`build: ...` |
+
+Other types follow the same idea: the issue type determines the branch
+prefix and normally maps to the corresponding commit `type`.
+
+This naming is not enforced by tools, but it is the **expected default**.
+Stick to it unless you have a clear reason not to; it keeps issues, branches,
+and history easy to follow.
 
 ---
 
 ## 3. Pull Requests
 
+This section is the main reference for how we use pull requests. The [Git workflow](docs/git-workflow.md) shows where PRs fit into the branch and release process.
+
 ### 3.1 General rules
 
 - All non-trivial work goes through a pull request.
-– By default, the PR is directed to the integration branch develop. We use the main branch only for release merges.
-- Link the PR to the relevant issue: `Closes #NN` or `Related to #NN`.
+- By default, the PR is directed to the integration branch `develop`. We use the `main` branch only for release merges.
+- Link the PR to the relevant issue:
+  - `Closes #NN` for issues that are fully resolved,
+  - `Related to #NN` for partial or exploratory work.
 - Keep PRs focused on a single logical change set (or a tight group of related ones).
 
 ### 3.2 PR title and description
 
 **PR title** should summarize the outcome and indicate the area.
+
 **Format:**
 
 ```text
-<area>: <short outcome in imperative or past-tense>
+<area>: <short outcome (imperative or past tense, sentence case)>
 ```
+where:
+- `<area>` should be one of the defined project areas (lowercase).
+- `<short outcome>` starts with a capital letter and is written in sentence case.
+
 Examples:
-  • meta: Add GitHub issue and PR templates
-  • build: Setup base Gradle build
-  • labels: Implement label scheme and update existing issues
-  • docs: Document issue workflow in CONTRIBUTING
+- workflow: Add GitHub issue and PR templates
+- build: Setup base Gradle build
 
-Note: PR titles are not conventional commits.
-Commits may use chore:, feat:, fix: etc, while PR titles use <area>:.
+> Note: PR titles are not conventional commits.
+> Commits may use `chore:`, `feat:`, `fix:`, etc., while PR titles use `<area>`.
 
-**Description** should cover:
-
-```markdown
-## Summary
-
-What this PR does in 1–3 sentences.
-
-## Details
-
-- Key change 1
-- Key change 2
-- Any breaking or notable behavioral change
-
-## Testing
-
-- How this was tested (commands, scenarios).
-- Mention if some parts are intentionally untested (and why).
-```
+The **PR description** should follow [`pull_request_template.md`](.github/pull_request_template.md).
 
 ### 3.3 Reviews and merging
-  • At least one other team member reviews non-trivial changes.
-	• Author is responsible for:
-	  •	Making sure the build passes.
-	  •	Ensuring tests are green or explicitly calling out what’s missing.
-	• Reviewer focuses on:
-	  •	Correctness and impact.
-	  •	Clarity of code and tests.
-	  •	Consistency with existing patterns in the codebase.
+- At least one other team member reviews non-trivial changes.
+- Author is responsible for:
+    - Making sure the build passes.
+    - Ensuring tests are green or explicitly calling out what’s missing.
+- Reviewer focuses on:
+    - Correctness and impact.
+    - Clarity of code and tests.
+    - Consistency with existing patterns in the codebase.
 
-### 3.4 Merge strategy
+By default, we use **Squash and merge** into `develop`.
+See [Git workflow](docs/git-workflow.md) for details.
 
-For feature branches, we use **Squash and merge**.
-- Each PR into develop is merged as a **single commit**. This keeps the develop history linear and groups changes by task.
-- The final commit message should be cleaned up before merging:
-  - Subject describes what changed.
-  - Body, if needed, can summarize important details or reference issues.
-- Intermediate commits inside the PR are treated as work in progress and are not preserved in the main history.
+---
 
-Release merges.
-- Changes from develop to main are merged separately (no squash) as the release becomes ready.
-- This preserves the detailed history of all commits included in the release, making it easier to track changes and roll back.
-- After merging, the release is tagged and main is updated.
+## 4. Testing and code style
 
-If other long-lived branches appear in the future (e.g., release/* or hotfix/*), their merge rules will be described here.
-
-⸻
-
-4. Testing and code style
-
-4.1 Tests
+### 4.1 Tests
 
 Baseline expectations:
-	•	Bug fixes: add or adjust tests that demonstrate the bug and the fix.
-	•	New features: add tests for core behavior.
-	•	Refactors: keep coverage at least equivalent, avoid silently dropping tests.
+- **Bug fixes**: add or adjust tests that demonstrate the bug and the fix.
+- **New features**: add tests for core behavior.
+- **Refactors**: keep coverage at least equivalent, avoid silently dropping tests.
 
-Use the project’s standard commands, for example:
+By default:
+- locally, run at least `./gradlew test` before opening a PR;
+- CI will normally run `./gradlew check`, which may include additional verification steps (style checks, static analysis, etc.).
 
-```bash
-./gradlew test
-./gradlew check
-```
-(Adjust if the actual commands will changed.)
+### 4.2 Style and structure
 
-4.2 Style and structure
-	•	Follow the style of the file you are editing.
-	•	Prefer clear, readable code over clever shortcuts.
-	•	Avoid mixing large refactors with behavioral changes in the same PR; split into separate PRs when possible.
+- Follow the style of the file you are editing.
+- Prefer clear, readable code over clever shortcuts.
+- Avoid mixing large refactors with behavioral changes in the same PR; split into separate PRs when possible.
 
-⸻
+---
 
-5. Project configuration & process
+## 5. Changing projec rules
 
-Changes to project-wide behavior (CI, build, label scheme, branching strategy, etc.) should:
-	1.	Have an issue (usually labeled meta and/or chore).
-	2.	Be documented briefly in this file or in a nearby doc once stable.
-	3.	Be communicated in PR description so the rest of the team is aware.
+Some work doesn’t change product behavior at all. Instead, it changes **how the project itself is run**: labels, branching strategy, CI rules, templates, required checks, etc.
 
-This file is the place where we collect these decisions. If the process changes, update CONTRIBUTING.md instead of letting reality and docs drift apart.
+Treat this work explicitly, as first-class, instead of sneaking it into random feature branches.
 
-## Issue labels
+When you change project rules:
 
-We use a small, consistent label set to keep the issue tracker readable.
+1. Create an issue labeled `meta`.
+2. Make the change via a pull request.
+3. Update this guide and/or nearby docs so the new process is documented.
+4. Call out the change in the PR description so it’s easy to discover later.
 
-**Type labels**
+This file is the entry point for “how we work”. If reality and this guide
+ever diverge, either update the guide or revert the process change.
 
-- `feature` – New feature or request.
-- `enhancement` – Small improvements or extensions to existing functionality; no brand-new features.
-- `bug` – Unexpected problem or incorrect behavior.
-- `chore` – Maintenance work: refactors, dependency bumps, build/CI tweaks without user-facing changes.
-- `documentation` – Improvements or additions to documentation.
-- `meta` – Project / repo / GitHub configuration and process tasks.
+---
 
-**Workflow labels**
+## 6. Further reading
 
-- `question` – Issue needs clarification or more information.
-- `help wanted` – Maintainer would like help on this.
-- `good first issue` – Small, well-scoped issue suitable for newcomers.
-- `duplicate` – This issue is already covered by another one.
-- `wontfix` – Decided not to work on this issue.
+For detailed conventions, see:
 
-### Priority labels
+- [`docs/git-workflow.md`](docs/git-workflow.md) – branching model and merge strategy.
+- [`docs/project-meta.md`](docs/project-meta.md) – label scheme, priorities, and project meta.
+- [`docs/commit-conventions.md`](docs/commit-conventions.md) – commit message format and examples.
 
-We use priority labels to express how urgent an issue is from the project perspective.
-
-These are set during triage by maintainers. Contributors don’t have to guess the right priority.
-
-- `priority:P0` – Critical. Must be addressed as soon as possible. 
-  - Examples: production-blocking bugs, broken main branch, issues that block a milestone.
-
-- `priority:P1` – Important. Should be done for the current or next planned milestone.
-  - Examples: key features, significant improvements, non-blocking but high-impact bugs.
-
-- `priority:P2` – Normal. Useful work that can be scheduled after P0/P1 items.
-  - Examples: nice-to-have enhancements, cleanups, non-urgent refactors, minor UX / DX polish.
-
- - `priority:P3` – Low. Backlog / “someday, if it still matters”.
+---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,80 +1,257 @@
-# Singularity – Contributing Guide
+# Singularity – Development Guide
 
-This is the entry point for how we work on Singularity. It shows where to start and points to the detailed rules that keep the workflow predictable and easy to follow over time.
+This guide explains how we use issues, labels, branches, commits, and pull requests when working on Singularity.
 
-Use this guide to orient yourself, then dive into the linked documents when you need specifics.
+The goal is to keep the workflow predictable, traceable, and easy to work with over time.
 
 ---
 
 ## Quick start
 
-1. Find or file an issue for your work.
-2. Create a short-lived branch from `develop`.
-3. Commit with structured messages.
-4. Open a pull request into `develop` and link the issue.
-5. Keep tests green and follow review feedback.
+1. Open or pick an issue before you start work (except for tiny, obvious fixes).
+2. Branch from `develop` using a short-lived, typed name (for example `feature/add-basic-login`).
+3. Commit with structured messages that match the branch/issue type.
+4. Open a PR into `develop`, link the issue, and follow the PR template.
+5. Keep tests green; add or adjust them for new behavior or fixes.
 
-The sections below summarize the expectations for each step and link to the detailed rules.
-
----
-
-## Issues
-
-- Create an issue for anything non-trivial: new features, bug fixes, refactors, CI/build changes, documentation, or project meta work.
-- Keep titles short, factual, and outcome-focused; avoid prefixes like `build:` or `meta:`.
-- Apply labels for **type**, **area**, **priority**, and **workflow** so the project board stays filterable.
-- Use the templates under [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) to keep reports consistent.
-
-> Full label definitions and examples live in [Project meta](docs/project-meta.md).
+The sections below contain the detailed rules and examples for each step.
 
 ---
 
-## Branches and commits
+## 1. Issues
 
-- We use a simple `develop` → `main` model; everyday work branches from `develop`.
-- Name branches as `<issue-type>/<short-description>`, e.g. `feature/add-basic-login` or `meta/update-labels`.
-- Keep the “kind of work” consistent across the issue, branch prefix, and commit type (`bug` → `bugfix/...` → `fix: ...`).
-- Commit messages follow `<type>: <short summary>` and stay focused; avoid giant catch-all commits.
+### 1.1 When to create an issue
 
-> Detailed branching rules and commit examples are in [Git workflow](docs/git-workflow.md) and [Commit conventions](docs/commit-conventions.md).
+Create an issue for:
+
+- New features or behavior changes.
+- Bug reports.
+- Refactors, build/CI changes, dependency updates.
+- Documentation work.
+- Project/repo/process changes (labels, CI, conventions, etc).
+
+Avoid drive-by changes without an issue, except for truly trivial fixes (typos in comments, tiny doc wording, etc).
+
+### 1.2 Issue titles
+
+Keep titles:
+
+- Short and factual.
+- Focused on outcome, not implementation details.
+
+Examples:
+
+- `Setup Gradle project`
+- `Define GitHub label scheme`
+- `Fix NPE when payload is null`
+
+Do **not** put type/area/priority prefixes in the issue title (`build:`, `meta:`, etc).  
+
+### 1.3 Issue labels (overview)
+
+We use GitHub labels to classify issues and project items along four axes:
+
+- **Type** – what kind of work this is  
+- **Area** – which part of the system or process it primarily affects  
+- **Priority** – how urgent it is for the project  
+- **Workflow** – special handling / state (question, duplicate, wontfix, etc.)
+
+These axes are implemented as labels (for example, `feature`, `bug`,
+`priority:P1`, `question`), so that the project board stays easy to filter and scan.
+
+When you create or triage an issue:
+
+- **Type**  
+  - Apply **exactly one** type label (required), e.g. `feature`, `enhancement`, `bug`, `chore`, `documentation`, `meta`.
+- **Area**  
+  - Apply **one** area label (required), e.g. `domain`, `auth`, `workflow`, `build`, `infra`.  
+  - If an issue truly affects multiple areas in a balanced way, you may add
+    more than one area label, but this should be rare. Prefer choosing the single
+    area with the most visible impact to keep filtering on the project board useful.
+- **Priority**  
+  - Apply **at most one** priority label (`priority:P0`..`priority:P3`).  
+  - New issues may be created without a priority; maintainers set or adjust priority during triage.
+- **Workflow**  
+  - Add workflow labels only when needed: `question`, `help wanted`, `good first issue`, `duplicate`, `wontfix`, etc.  
+  - These refine handling/state and never replace type, area, or priority.
+
+Full definitions of each label and axis live in [Project meta](docs/project-meta.md).
+
+### 1.4 Issue templates
+
+When opening an issue, use the provided templates under [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE):
+
+  - use the **general** template for features, enhancements, chores, and meta tasks;
+  - use the **bug** template for defects and regressions.
+
+The goal is to keep issues consistent and easy to triage.
+
+Templates are a starting point, not a straitjacket, but issues should contain at least the information these templates ask for.
 
 ---
 
-## Pull requests
+## 2. Branches and commits
 
-- Route PRs to `develop` by default; `main` is used only for release merges.
-- Link PRs to issues (`Closes #NN` for completed work, `Related to #NN` for partial/exploratory changes).
-- Keep PRs scoped to a single logical change set.
-- Format titles as `<area>: <short outcome>` in sentence case, and follow the [`pull_request_template.md`](.github/pull_request_template.md) for the description.
-- Expect at least one review for non-trivial work; default merge strategy is **Squash and merge** into `develop`.
+This section is a short version. Full details are in the [Git workflow](docs/git-workflow.md) document.
 
-> See [Git workflow](docs/git-workflow.md#3-merge-strategy) for merge details.
+### 2.1 Branching model (high-level)
+
+We use a simple `main`/`develop` model:
+
+- `develop` is the primary **integration branch** for day-to-day work.
+- `main` is reserved for **release-ready** code and is updated from `develop` when a release is cut.
+
+### 2.2 Branch naming
+
+We use short-lived branches created from `develop` with names in the form:
+
+```text
+<issue-type>/<short-description>
+```
+- `<issue-type>` is usually one of: `feature`, `bugfix`, `chore`, `docs`, `meta`;
+- `<short-description>` is a short, kebab-case summary, e.g. `add-basic-login`.
+
+We do not encode issue numbers in branch names.
+
+For full details and examples, see the [Git workflow](docs/git-workflow.md#12-short-lived-branches).
+
+### 2.3 Commit messages
+
+At a glance, they usually look like:
+
+```text
+<type>: <short summary>
+```
+
+Examples:
+
+- `feat: add refresh token support`
+- `fix: handle null payload in request`
+- `build: configure Gradle wrapper`
+
+Keep commit scope focused and avoid huge “misc” blobs. 
+
+The detailed rules (allowed types, scopes, structure) are in the [Commit conventions](docs/commit-conventions.md) document.
 
 ---
 
-## Testing and quality
+### 2.4 Naming consistency (issue → branch → commit)
 
-- Bug fixes and features should ship with tests that cover the behavior.
-- Run `./gradlew test` locally before opening a PR; CI will typically run `./gradlew check`.
-- Match the style of surrounding code and avoid mixing large refactors with behavioral changes.
+As a rule of thumb, the “kind of work” stays the same across issues,
+branches, and commits, even if the wording changes:
+
+| Issue type      | Typical branch prefix      | Typical commit type(s) |
+|-----------------|----------------------------|------------------------|
+| `bug`           | `bugfix/...`               | `fix: ...`             |
+| `feature`       | `feature/...`              | `feat: ...`            |
+| `documentation` | `docs/...`                 | `docs: ...`            |
+| `meta`          | `meta/...`                 | `meta: ...`            |
+| `chore`         | `chore/...`                | `chore: ...`or`build: ...` |
+
+Other types follow the same idea: the issue type determines the branch
+prefix and normally maps to the corresponding commit `type`.
+
+This naming is not enforced by tools, but it is the **expected default**.
+Stick to it unless you have a clear reason not to; it keeps issues, branches,
+and history easy to follow.
 
 ---
 
-## Changing project rules
+## 3. Pull Requests
 
-Changes to how the project is run—labels, templates, required checks, conventions—should be explicit:
+This section is the main reference for how we use pull requests. The [Git workflow](docs/git-workflow.md) shows where PRs fit into the branch and release process.
+
+### 3.1 General rules
+
+- All non-trivial work goes through a pull request.
+- By default, the PR is directed to the integration branch `develop`. We use the `main` branch only for release merges.
+- Link the PR to the relevant issue:
+  - `Closes #NN` for issues that are fully resolved,
+  - `Related to #NN` for partial or exploratory work.
+- Keep PRs focused on a single logical change set (or a tight group of related ones).
+
+### 3.2 PR title and description
+
+**PR title** should summarize the outcome and indicate the area.
+
+**Format:**
+
+```text
+<area>: <short outcome (imperative or past tense, sentence case)>
+```
+where:
+- `<area>` should be one of the defined project areas (lowercase).
+- `<short outcome>` starts with a capital letter and is written in sentence case.
+
+Examples:
+- workflow: Add GitHub issue and PR templates
+- build: Setup base Gradle build
+
+> Note: PR titles are not conventional commits.
+> Commits may use `chore:`, `feat:`, `fix:`, etc., while PR titles use `<area>`.
+
+The **PR description** should follow [`pull_request_template.md`](.github/pull_request_template.md).
+
+### 3.3 Reviews and merging
+- At least one other team member reviews non-trivial changes.
+- Author is responsible for:
+    - Making sure the build passes.
+    - Ensuring tests are green or explicitly calling out what’s missing.
+- Reviewer focuses on:
+    - Correctness and impact.
+    - Clarity of code and tests.
+    - Consistency with existing patterns in the codebase.
+
+By default, we use **Squash and merge** into `develop`.
+See [Git workflow](docs/git-workflow.md) for details.
+
+---
+
+## 4. Testing and code style
+
+### 4.1 Tests
+
+Baseline expectations:
+- **Bug fixes**: add or adjust tests that demonstrate the bug and the fix.
+- **New features**: add tests for core behavior.
+- **Refactors**: keep coverage at least equivalent, avoid silently dropping tests.
+
+By default:
+- locally, run at least `./gradlew test` before opening a PR;
+- CI will normally run `./gradlew check`, which may include additional verification steps (style checks, static analysis, etc.).
+
+### 4.2 Style and structure
+
+- Follow the style of the file you are editing.
+- Prefer clear, readable code over clever shortcuts.
+- Avoid mixing large refactors with behavioral changes in the same PR; split into separate PRs when possible.
+
+---
+
+## 5. Changing project rules
+
+Some work doesn’t change product behavior at all. Instead, it changes **how the project itself is run**: labels, branching strategy, CI rules, templates, required checks, etc.
+
+Treat this work explicitly, as first-class, instead of sneaking it into random feature branches.
+
+When you change project rules:
 
 1. Create an issue labeled `meta`.
-2. Make the change via a PR.
-3. Update this guide and related docs so the new rule is documented.
-4. Call out the process change in the PR description for easy discovery later.
+2. Make the change via a pull request.
+3. Update this guide and/or nearby docs so the new process is documented.
+4. Call out the change in the PR description so it’s easy to discover later.
 
-If reality and these docs diverge, update the docs or roll back the process change.
+This file is the entry point for “how we work”. If reality and this guide
+ever diverge, either update the guide or revert the process change.
 
 ---
 
-## Further reading
+## 6. Further reading
+
+For detailed conventions, see:
 
 - [`docs/git-workflow.md`](docs/git-workflow.md) – branching model and merge strategy.
 - [`docs/project-meta.md`](docs/project-meta.md) – label scheme, priorities, and project meta.
 - [`docs/commit-conventions.md`](docs/commit-conventions.md) – commit message format and examples.
+
+---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,245 +1,80 @@
-# Singularity – Development Guide
+# Singularity – Contributing Guide
 
-This guide explains how we use issues, labels, branches, commits, and pull requests when working on Singularity.
+This is the entry point for how we work on Singularity. It shows where to start and points to the detailed rules that keep the workflow predictable and easy to follow over time.
 
-The goal is to keep the workflow predictable, traceable, and easy to work with over time.
-
----
-
-## 1. Issues
-
-### 1.1 When to create an issue
-
-Create an issue for:
-
-- New features or behavior changes.
-- Bug reports.
-- Refactors, build/CI changes, dependency updates.
-- Documentation work.
-- Project/repo/process changes (labels, CI, conventions, etc).
-
-Avoid drive-by changes without an issue, except for truly trivial fixes (typos in comments, tiny doc wording, etc).
-
-### 1.2 Issue titles
-
-Keep titles:
-
-- Short and factual.
-- Focused on outcome, not implementation details.
-
-Examples:
-
-- `Setup Gradle project`
-- `Define GitHub label scheme`
-- `Fix NPE when payload is null`
-
-Do **not** put type/area/priority prefixes in the issue title (`build:`, `meta:`, etc).  
-
-### 1.3 Issue labels (overview)
-
-We use GitHub labels to classify issues and project items along four axes:
-
-- **Type** – what kind of work this is  
-- **Area** – which part of the system or process it primarily affects  
-- **Priority** – how urgent it is for the project  
-- **Workflow** – special handling / state (question, duplicate, wontfix, etc.)
-
-These axes are implemented as labels (for example, `feature`, `bug`,
-`priority:P1`, `question`), so that the project board stays easy to filter and scan.
-
-When you create or triage an issue:
-
-- **Type**  
-  - Apply **exactly one** type label (required), e.g. `feature`, `enhancement`, `bug`, `chore`, `documentation`, `meta`.
-- **Area**  
-  - Apply **one** area label (required), e.g. `domain`, `auth`, `workflow`, `build`, `infra`.  
-  - If an issue truly affects multiple areas in a balanced way, you may add
-    more than one area label, but this should be rare. Prefer choosing the single
-    area with the most visible impact to keep filtering on the project board useful.
-- **Priority**  
-  - Apply **at most one** priority label (`priority:P0`..`priority:P3`).  
-  - New issues may be created without a priority; maintainers set or adjust priority during triage.
-- **Workflow**  
-  - Add workflow labels only when needed: `question`, `help wanted`, `good first issue`, `duplicate`, `wontfix`, etc.  
-  - These refine handling/state and never replace type, area, or priority.
-
-Full definitions of each label and axis live in [Project meta](docs/project-meta.md).
-
-### 1.4 Issue templates
-
-When opening an issue, use the provided templates under [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE):
-
-  - use the **general** template for features, enhancements, chores, and meta tasks;
-  - use the **bug** template for defects and regressions.
-
-The goal is to keep issues consistent and easy to triage.
-
-Templates are a starting point, not a straitjacket, but issues should contain at least the information these templates ask for.
+Use this guide to orient yourself, then dive into the linked documents when you need specifics.
 
 ---
 
-## 2. Branches and commits
+## Quick start
 
-This section is a short version. Full details are in the [Git workflow](docs/git-workflow.md) document.
+1. Find or file an issue for your work.
+2. Create a short-lived branch from `develop`.
+3. Commit with structured messages.
+4. Open a pull request into `develop` and link the issue.
+5. Keep tests green and follow review feedback.
 
-### 2.1 Branching model (high-level)
-
-We use a simple `main`/`develop` model:
-
-- `develop` is the primary **integration branch** for day-to-day work.
-- `main` is reserved for **release-ready** code and is updated from `develop` when a release is cut.
-
-### 2.2 Branch naming
-
-We use short-lived branches created from `develop` with names in the form:
-
-```text
-<issue-type>/<short-description>
-```
-- `<issue-type>` is usually one of: `feature`, `bugfix`, `chore`, `docs`, `meta`;
-- `<short-description>` is a short, kebab-case summary, e.g. `add-basic-login`.
-
-We do not encode issue numbers in branch names.
-
-For full details and examples, see the [Git workflow](docs/git-workflow.md#12-short-lived-branches).
-
-### 2.3 Commit messages
-
-At a glance, they usually look like:
-
-```text
-<type>: <short summary>
-```
-
-Examples:
-
-- `feat: add refresh token support`
-- `fix: handle null payload in request`
-- `build: configure Gradle wrapper`
-
-Keep commit scope focused and avoid huge “misc” blobs. 
-
-The detailed rules (allowed types, scopes, structure) are in the [Commit conventions](docs/commit-conventions.md) document.
+The sections below summarize the expectations for each step and link to the detailed rules.
 
 ---
 
-### 2.4 Naming consistency (issue → branch → commit)
+## Issues
 
-As a rule of thumb, the “kind of work” stays the same across issues,
-branches, and commits, even if the wording changes:
+- Create an issue for anything non-trivial: new features, bug fixes, refactors, CI/build changes, documentation, or project meta work.
+- Keep titles short, factual, and outcome-focused; avoid prefixes like `build:` or `meta:`.
+- Apply labels for **type**, **area**, **priority**, and **workflow** so the project board stays filterable.
+- Use the templates under [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) to keep reports consistent.
 
-| Issue type      | Typical branch prefix      | Typical commit type(s) |
-|-----------------|----------------------------|------------------------|
-| `bug`           | `bugfix/...`               | `fix: ...`             |
-| `feature`       | `feature/...`              | `feat: ...`            |
-| `documentation` | `docs/...`                 | `docs: ...`            |
-| `meta`          | `meta/...`                 | `meta: ...`            |
-| `chore`         | `chore/...`                | `chore: ...`or`build: ...` |
-
-Other types follow the same idea: the issue type determines the branch
-prefix and normally maps to the corresponding commit `type`.
-
-This naming is not enforced by tools, but it is the **expected default**.
-Stick to it unless you have a clear reason not to; it keeps issues, branches,
-and history easy to follow.
+> Full label definitions and examples live in [Project meta](docs/project-meta.md).
 
 ---
 
-## 3. Pull Requests
+## Branches and commits
 
-This section is the main reference for how we use pull requests. The [Git workflow](docs/git-workflow.md) shows where PRs fit into the branch and release process.
+- We use a simple `develop` → `main` model; everyday work branches from `develop`.
+- Name branches as `<issue-type>/<short-description>`, e.g. `feature/add-basic-login` or `meta/update-labels`.
+- Keep the “kind of work” consistent across the issue, branch prefix, and commit type (`bug` → `bugfix/...` → `fix: ...`).
+- Commit messages follow `<type>: <short summary>` and stay focused; avoid giant catch-all commits.
 
-### 3.1 General rules
-
-- All non-trivial work goes through a pull request.
-- By default, the PR is directed to the integration branch `develop`. We use the `main` branch only for release merges.
-- Link the PR to the relevant issue:
-  - `Closes #NN` for issues that are fully resolved,
-  - `Related to #NN` for partial or exploratory work.
-- Keep PRs focused on a single logical change set (or a tight group of related ones).
-
-### 3.2 PR title and description
-
-**PR title** should summarize the outcome and indicate the area.
-
-**Format:**
-
-```text
-<area>: <short outcome (imperative or past tense, sentence case)>
-```
-where:
-- `<area>` should be one of the defined project areas (lowercase).
-- `<short outcome>` starts with a capital letter and is written in sentence case.
-
-Examples:
-- workflow: Add GitHub issue and PR templates
-- build: Setup base Gradle build
-
-> Note: PR titles are not conventional commits.
-> Commits may use `chore:`, `feat:`, `fix:`, etc., while PR titles use `<area>`.
-
-The **PR description** should follow [`pull_request_template.md`](.github/pull_request_template.md).
-
-### 3.3 Reviews and merging
-- At least one other team member reviews non-trivial changes.
-- Author is responsible for:
-    - Making sure the build passes.
-    - Ensuring tests are green or explicitly calling out what’s missing.
-- Reviewer focuses on:
-    - Correctness and impact.
-    - Clarity of code and tests.
-    - Consistency with existing patterns in the codebase.
-
-By default, we use **Squash and merge** into `develop`.
-See [Git workflow](docs/git-workflow.md) for details.
+> Detailed branching rules and commit examples are in [Git workflow](docs/git-workflow.md) and [Commit conventions](docs/commit-conventions.md).
 
 ---
 
-## 4. Testing and code style
+## Pull requests
 
-### 4.1 Tests
+- Route PRs to `develop` by default; `main` is used only for release merges.
+- Link PRs to issues (`Closes #NN` for completed work, `Related to #NN` for partial/exploratory changes).
+- Keep PRs scoped to a single logical change set.
+- Format titles as `<area>: <short outcome>` in sentence case, and follow the [`pull_request_template.md`](.github/pull_request_template.md) for the description.
+- Expect at least one review for non-trivial work; default merge strategy is **Squash and merge** into `develop`.
 
-Baseline expectations:
-- **Bug fixes**: add or adjust tests that demonstrate the bug and the fix.
-- **New features**: add tests for core behavior.
-- **Refactors**: keep coverage at least equivalent, avoid silently dropping tests.
-
-By default:
-- locally, run at least `./gradlew test` before opening a PR;
-- CI will normally run `./gradlew check`, which may include additional verification steps (style checks, static analysis, etc.).
-
-### 4.2 Style and structure
-
-- Follow the style of the file you are editing.
-- Prefer clear, readable code over clever shortcuts.
-- Avoid mixing large refactors with behavioral changes in the same PR; split into separate PRs when possible.
+> See [Git workflow](docs/git-workflow.md#3-merge-strategy) for merge details.
 
 ---
 
-## 5. Changing projec rules
+## Testing and quality
 
-Some work doesn’t change product behavior at all. Instead, it changes **how the project itself is run**: labels, branching strategy, CI rules, templates, required checks, etc.
+- Bug fixes and features should ship with tests that cover the behavior.
+- Run `./gradlew test` locally before opening a PR; CI will typically run `./gradlew check`.
+- Match the style of surrounding code and avoid mixing large refactors with behavioral changes.
 
-Treat this work explicitly, as first-class, instead of sneaking it into random feature branches.
+---
 
-When you change project rules:
+## Changing project rules
+
+Changes to how the project is run—labels, templates, required checks, conventions—should be explicit:
 
 1. Create an issue labeled `meta`.
-2. Make the change via a pull request.
-3. Update this guide and/or nearby docs so the new process is documented.
-4. Call out the change in the PR description so it’s easy to discover later.
+2. Make the change via a PR.
+3. Update this guide and related docs so the new rule is documented.
+4. Call out the process change in the PR description for easy discovery later.
 
-This file is the entry point for “how we work”. If reality and this guide
-ever diverge, either update the guide or revert the process change.
+If reality and these docs diverge, update the docs or roll back the process change.
 
 ---
 
-## 6. Further reading
-
-For detailed conventions, see:
+## Further reading
 
 - [`docs/git-workflow.md`](docs/git-workflow.md) – branching model and merge strategy.
 - [`docs/project-meta.md`](docs/project-meta.md) – label scheme, priorities, and project meta.
 - [`docs/commit-conventions.md`](docs/commit-conventions.md) – commit message format and examples.
-
----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ branches, and commits, even if the wording changes:
 | `feature`       | `feature/...`              | `feat: ...`            |
 | `documentation` | `docs/...`                 | `docs: ...`            |
 | `meta`          | `meta/...`                 | `meta: ...`            |
-| `chore`         | `chore/...`                | `chore: ...`or`build: ...` |
+| `chore`         | `chore/...`                | `chore: ...` or `build: ...` |
 
 Other types follow the same idea: the issue type determines the branch
 prefix and normally maps to the corresponding commit `type`.

--- a/docs/commit-conventions.md
+++ b/docs/commit-conventions.md
@@ -1,0 +1,105 @@
+# Commit Conventions
+
+We use a lightweight convention for commit messages to keep history readable and to make it easier to understand what changed.
+
+The goal is structure and clarity, not ceremony for its own sake.
+
+For how commit messages fit into the overall workflow (issues, branches, PRs),
+see the [Contributing guide – Commit messages](../CONTRIBUTING.md#23-commit-messages).
+
+---
+
+## 1. Basic format
+
+The basic format is:
+
+```text
+<type>: <short summary>
+```
+
+Optionally, you can add a scope:
+```text
+<type>(scope): <short summary>
+```
+
+- **Commit type** – *what actually changed in this diff?*  
+
+Keep the summary:
+- in present tense where it makes sense ("add", "fix", "update"), or
+- as a concise description of what changed.
+
+---
+
+## 2. Allowed types
+
+| Type   | Mainly used for                                  |
+|--------|--------------------------------------------------|
+| feat   | New behavior / capability                        |
+| fix    | Bug fixes                                        |
+| docs   | Documentation-only changes                       |
+| chore  | Refactors, deps, internal cleanups               |
+| build  | Build & CI/CD configuration                      |
+| meta   | Repo/process metadata (templates, CODEOWNERS, …) |
+
+Examples:
+- `feat: add basic file upload endpoint`
+- `fix: handle null payload in task update`
+- `chore: update Gradle wrapper`
+- `docs: document issue workflow`
+- `build: configure base CI pipeline`
+- `meta(workflow): introduce develop integration branch`
+
+Other types may appear if the project later needs them, but this set should cover most cases.
+
+---
+
+## 3. Scopes (optional)
+
+Scopes are an optional hint about the area the commit touches.
+For now, the scopes should use the same area labels that are defined in the [Project meta](docs/project-meta.md#4-areas).
+
+Examples:
+- `feat(domain): add domain model for file metadata`
+- `fix(domain): handle invalid status transition`
+- `docs(workflow): describe squash merge into develop`
+- `meta(workflow): introduce issue templates config`
+
+Avoid meaningless scopes like:
+- `build(build): enable tests in CI pipeline`
+
+Use scopes when they genuinely help; don't invent them just to fill the space.
+
+---
+
+## 4. Commit size and structure
+
+- Prefer small, coherent commits over huge "misc" commits.
+- Each commit should represent a logically consistent change:
+  - one bug fix,
+  - one refactor,
+  - one new piece of behavior.
+- Avoid mixing large refactors with behavioral changes:
+  - If you must, split into:
+    - `chore: refactor X`
+    - `feat: change behavior Y`
+
+Before opening a PR, it is okay to:
+- squash noisy WIP commits for clear history or reviewers,
+- reorder commits for clarity (if history is not yet shared),
+- clean up messages so they reflect what the commit actually does.
+
+---
+
+## 5. Relationship to PR titles
+
+- Commits describe individual steps; 
+- PR titles describe the overall outcome.
+
+- Commit messages use `<type>: <summary>`.
+- Pull requests use `<area>: <short outcome>`.
+
+---
+
+If these conventions ever become a burden instead of a help, we will adjust them. The point is clarity, not ritual.
+
+---

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,150 @@
+# Git Workflow
+
+This document describes how we use branches and merges in the Singularity repository.
+
+The goal is to keep history clean, make it easy to understand what changed and why, and avoid conflicts between parallel tasks.
+
+The [Contributing guide](../CONTRIBUTING.md#2-branches-and-commits) explains how branches, labels, commits, and pull requests fit together in the overall workflow. This document focuses on the branching and merge strategy.
+
+---
+
+## 1. Branches
+
+### 1.1 Long-lived branches
+
+We use two primary long-lived branches:
+
+- `main`
+  - Always points to the latest **release-quality** state.
+  - Protected: changes come only from merges (no direct pushes).
+  - Used to tag releases.
+
+- `develop`
+  - Primary **integration branch** for active development.
+  - All feature, bugfix, docs and meta work is merged into `develop` first.
+  - Also protected: changes go through pull requests.
+
+Additional long-lived branches (e.g. `release/*`, `hotfix/*`) may appear later if the project needs them. Their rules will be documented here.
+
+### 1.2 Short-lived branches
+
+All day-to-day work happens in short-lived branches created from `develop`:
+
+Branches are named using the pattern:
+
+```text
+<issue-type>/<short-description>
+```
+Use short, kebab-case descriptions in the `<short-description>` part.
+
+We do not encode issue numbers in branch names. The mapping between work and
+issues is kept through issue/PR links (for example, `Closes #NN`) and the project board.
+
+Prefixes correspond to issue types defined in the [Project meta - Issue Labels](project-meta.md#1-issue-labels-types)
+
+- feature/<short-description>        – for `feature` issues
+- enhancement/<short-description>    – for `enhancement` issues
+- bugfix/<short-description>         – for `bug` issues
+- chore/<short-description>          – for `chore` issues
+- docs/<short-description>           – for `documentation` issues
+- meta/<short-description>           – for `meta` issues
+
+Examples:
+
+- `feature/add-basic-login`
+- `bugfix/fix-login-status-code`
+- `chore/remove-legacy-config`
+- `docs/update-readme-build-section`
+- `meta/adjust-bug-template`
+
+---
+
+## 2. Typical workflow
+
+Example for a feature:
+
+1. Create or reuse an issue, e.g. `#12 Enable Spotless`.
+2. Create a branch from `develop`:
+
+```bash
+git checkout develop
+git pull
+git checkout -b chore/spotless-setup
+```
+
+3. Commit changes using structured commit messages (see the [Commit conventions](commit-conventions.md)).
+4. Push the branch and open a pull request into `develop`.
+5. Follow the PR rules from [Contributing guide - Pull requests](../CONTRIBUTING.md#3-pull-requests).
+6. Once the PR is approved and CI is green, merge it according to the [merge strategy](#3-merge-strategy).
+7. Delete the short-lived branch once merged (both locally and remotely).
+
+This workflow applies to all short-lived branches.
+
+---
+
+## 3. Merge strategy
+
+### 3.1 Into `develop`: Squash and merge
+
+For branches targeting develop:
+
+- Use "**Squash and merge**":
+    - The entire branch is merged as a **single commit**.
+    - This keeps the develop history linear and groups changes by task/issue.
+
+- Before merging:
+    - Clean up the final commit message:
+        - Subject describes what changed.
+        - Body can summarize important details or reference issues.
+
+Intermediate commits inside the branch are treated as work-in-progress and are not preserved in the main history.
+
+### 3.2 From `develop` to `main`: Release merges
+
+When a release or milestone is ready:
+1. Make sure `develop` is in a stable state.
+2. Create a pull request from `develop` into `main`.
+3. Merge **without squash** (regular merge/--no-ff equivalent in the UI):
+    - The merge commit into `main` represents a release event.
+4. Tag the release on `main`:
+
+```bash
+git checkout main
+git pull
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+This makes it easy to:
+- see which changes are included in a release;
+- roll back to a previous release if needed.
+
+### 3.3 Handling conflicts
+
+If `develop` has moved forward and your branch is behind:
+- Prefer updating the branch before merging the PR:
+
+```bash
+git checkout feature/something
+git fetch origin
+git merge origin/develop
+# or, if you're comfortable with rebase:
+# git rebase origin/develop
+```
+- Resolve conflicts locally, run tests, then push the updated branch.
+- Avoid rebasing public branches that other people already depend on, unless everyone involved agrees.
+
+---
+
+## 4. Small / trivial changes
+
+Tiny fixes (typos, very small documentation tweaks) may be committed directly to develop if:
+- They clearly do not affect behavior.
+- CI passes.
+
+However, the default expectation remains: use short-lived branches and pull requests, even for small changes, to keep history and review consistent.
+
+---
+If the workflow evolves (additional long-lived branches, different strategies for hotfixes, etc.), this document and the [Contributing guide](../CONTRIBUTING.md#2-branches-and-commits) should be updated to reflect the actual process.
+
+---

--- a/docs/project-meta.md
+++ b/docs/project-meta.md
@@ -1,0 +1,101 @@
+# Project Meta: Labels, Areas, Priorities
+
+This document defines the label set and the meaning of each value.
+The goal is to have a consistent way to filter, triage, and reason about the backlog.
+
+The [Contributing guide](../CONTRIBUTING.md#13-issue-labels-overview) explains when and how labels
+are applied in day-to-day work; here we focus on the classification
+scheme itself (types, workflow labels, priorities, areas).
+
+---
+
+## 0. Axes of classification
+
+Labels help classify work along four axes:
+
+- **Issue type** – *why are we doing this / what kind of work is this?*  
+- **Area** – *which part of the system or process does this primarily relate to?*  
+- **Priority** – *how urgent is this for the project?*  
+- **Workflow** – *how should this issue be handled?* (question, help wanted, duplicate, wontfix, etc.)
+
+---
+
+## 1. Issue labels (types)
+
+These labels describe what kind of work an issue represents:
+
+- `feature` – new feature or user-visible behavior change.
+- `enhancement` – improvement or extension to existing functionality.
+- `bug` – unexpected problem or incorrect behavior.
+- `chore` – maintenance work without direct user-facing changes
+  (refactors, dependency updates, build/CI tweaks, technical cleanups).
+- `documentation` – work whose primary goal is to improve documentation
+  about the system (domains, features, APIs, architecture, usage, etc.).
+- `meta` – work whose primary goal is to change how the project and workflow
+  behave (label scheme, branch protection rules, CI/CD structure,
+  issue/PR templates, branching strategy, etc.).
+
+Classification is based on **impact**, not on which files are touched.
+
+---
+
+## 2. Workflow labels
+
+These labels describe the **state or special handling** of an issue.
+
+- `question` – issue needs clarification or more information.  
+- `help wanted` – maintainer is asking for help; open invitation to contributors.  
+- `good first issue` – small, well-scoped issue suitable for newcomers.  
+- `duplicate` – this issue is already covered by another one; link the canonical issue.  
+- `wontfix` – decided not to work on this issue (out of scope, wrong trade-offs, obsolete).
+
+Workflow labels refine how an issue should be handled.
+They do not replace type, area, or priority labels.
+
+---
+
+## 3. Priority labels
+
+Priority labels express how urgent an issue is for the project:
+
+- `priority:P0` – **Critical**: must be addressed as soon as possible
+  (broken build on `main`/`develop`, critical blocking bugs, milestone blockers).
+- `priority:P1` – **High**: important for the current or next milestone.
+- `priority:P2` – **Normal**: useful work scheduled after P0/P1 items.
+- `priority:P3` – **Low / Backlog**: “someday, if it still matters” items.
+
+---
+
+## 4. Areas
+In addition to labels, the project uses **areas** to describe the main
+context of the work.
+
+An area answers the question: *"Which part of the system or process does
+this primarily relate to?"*
+
+Typical areas:
+- `domain` – domain-level functionality.
+- `auth` – authentication and authorization.
+- `workflow` – process and workflow rules for working with the repo
+  (issues, labels, branches, PR conventions, etc.).
+- `build` – build system, CI/CD pipelines, automation, Gradle configuration.
+- `infra` – cross-cutting infrastructure: docker-compose, shared environments,
+  reverse proxy, deployment-related setup.
+
+The list of areas may evolve over time. When new areas are introduced, update the project board, [Contributing guide](../CONTRIBUTING.md#13-issue-labels-overview), and this document to keep them in sync.
+
+---
+
+## 5. Templates
+
+- Issue templates live under `.github/ISSUE_TEMPLATE/`:
+  - **general** – features, enhancements, chores, meta tasks.
+  - **bug** – defects and regressions.
+- The pull request template lives at [`pull_request_template.md`](../.github/pull_request_template.md) and enforces:
+  - Summary
+  - Details
+  - Testing
+
+The [Contributing guide](../CONTRIBUTING.md#14-issue-templates) describes how to use these templates in practice.
+
+---


### PR DESCRIPTION
## Summary

Polish and restructure the contribution workflow documentation.

Closes #10

## Details

Convert `CONTRIBUTING.md` into a high-level entry point and move detailed rules into dedicated documents:

- `docs/git-workflow.md`
- `docs/project-meta.md`
- `docs/commit-conventions.md`

## Testing

Not tested; documentation-only change.
